### PR TITLE
removing node 0.8 from travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: node_js
 node_js:
-    - "0.8"
     - "0.10"
     - "0.11"


### PR DESCRIPTION
Wasn't sure if you wanted to bump the `engines` in `package.json` to `>0.10.x` also.  Let me know if you wanted that too.  Sry about the EOL thrash.

fixes #5 
