### PR TITLE
Safeguards for OutgoingResponse timeout handler

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -60,8 +60,12 @@ Closer.prototype = {
         } else if (this.message instanceof http.ServerResponse) {
             try {
                 delete this.message.__closer;
-                this.message.writeHead(504, 'Gateway Timeout', {'Content-Type': 'text/plain'});
-                this.message.end('504 Gateway Timeout');
+                if (!this.message.headersSent) {
+                    this.message.writeHead(504, 'Gateway Timeout', {'Content-Type': 'text/plain'});
+                }
+                if (!this.message.finished) {
+                    this.message.end('504 Gateway Timeout');
+                }
             } catch (e) {
             }
         }
@@ -137,7 +141,7 @@ function exposeGlobalTimers(config) {
     if (config.out_req_timeout > 0) {
         process.setOutgoingRequestsTimeout(config.out_req_timeout);
     }
-    
+
 }
 
 /*
@@ -196,7 +200,7 @@ module.exports = function (config) {
         var count = null,
             conf = (req.mod_config) ? mergeConfig(config, req.mod_config) : config,
             reqEmit = req.emit;
-            
+
         if (!conf || (conf.enable !== "true" && conf.enable !== true)) {
             next();
             return;
@@ -205,7 +209,7 @@ module.exports = function (config) {
         if (typeof conf.post_max_size === "string") {
             conf.post_max_size = parseInt(conf.post_max_size, 10);
         }
-        
+
         if (typeof conf.uri_max_length === "string") {
             conf.uri_max_length = parseInt(conf.uri_max_length, 10);
         }
@@ -273,7 +277,7 @@ module.exports = function (config) {
             //  Forward all events to client
             reqEmit.apply(req, arguments);
         };
-        
+
         next();
     };
 };


### PR DESCRIPTION
This temporarily resolves an issue with `writeHead` being called even though the response has already ended. I will do another PR with removing the timer on response `end` which will be better, but these checks should still be there anyway.