### PR TITLE
Ensure we publish only the files we intend to npm registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,5 +37,8 @@
     "engines": {
         "node": ">4.x"
     },
+    "files": [
+        "lib/"
+    ],
     "dependencies": {}
 }


### PR DESCRIPTION
By putting a "files" section in our package.json.  This avoids publishing tests, coverage detritus, etc.